### PR TITLE
Allow RPCs to have Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `protobuf` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:protobuf_ex, "~> 0.6.0"}]
+  [{:protobuf_ex, "~> 0.6.1"}]
 end
 ```
 

--- a/lib/protobuf/protoc/generator/service.ex
+++ b/lib/protobuf/protoc/generator/service.ex
@@ -9,7 +9,7 @@ defmodule Protobuf.Protoc.Generator.Service do
     mod_name = desc.name |> Macro.camelize |> Util.attach_pkg(ctx.package)
     name = "#{ctx.package}.#{desc.name}"
     methods = Enum.map(desc.method, fn(m) ->
-      {generate_service_method(ctx, m), get_method_options(m)}
+      {generate_service_method(ctx, m), get_method_options(m), get_method_docs(m)}
     end)
     Protobuf.Protoc.Template.service(mod_name, name, methods)
   end
@@ -26,6 +26,27 @@ defmodule Protobuf.Protoc.Generator.Service do
       %{http: http} ->
         case http.pattern do
           {type, path} -> {type, path}
+          _ -> nil
+        end
+      _ -> nil
+    end
+  end
+
+  defp get_method_docs(%Google.Protobuf.MethodDescriptorProto{options: nil}), do: nil
+  defp get_method_docs(m) do
+    case m.options do
+      %{docs: docs} ->
+        case docs.description do
+          "" -> nil
+          desc when is_binary(desc) ->
+            docs =
+              desc
+              |> String.split("\n")
+              |> Enum.map(&String.trim/1)
+              |> Enum.join("\n  ")
+              |> String.trim()
+
+            "@doc \"\"\"\n  #{docs}\n  \"\"\"\n  "
           _ -> nil
         end
       _ -> nil

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Protobuf.Mixfile do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.6.1"
 
   def project do
     [app: :protobuf_ex,

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -1,9 +1,9 @@
 defmodule <%= mod_name %> do
   use Protobuf.Service
 
-<%= Enum.map methods, fn {method, nil} -> %>
-  rpc <%= method %>
-<% {method, {type, path}} -> %>
-  rpc <%= method %>, <%= type %>: "<%= path %>"
+<%= Enum.map methods, fn {method, nil, docs} -> %>
+  <%= if docs, do: docs, else: "" %>rpc <%= method %>
+<% {method, {type, path}, docs} -> %>
+  <%= if docs, do: docs, else: "" %>rpc <%= method %>, <%= type %>: "<%= path %>"
 <% end %>
 end


### PR DESCRIPTION
This patch adds a simple "Docs" option to our RPC service definitions, which is then added as Elixir `@doc` attributes, if specified. This can then be read at run-time for self-documenting APIs, e.g.

Note: we do our best to handle multi-line strings, which are poorly supported in Protobufs. Also, we could probably get argument types from the protobufs definition, but we currently do not do that and leave it up to the doc writer to do so.

```proto
service AccountService {
    rpc account(AccountRequest) returns (AccountResponse) {
        option (google.api.http) = { get: "/account" };
        option (google.api.docs) = {
            description:
                "Get user account information\n"
                "\n"
                "This adds cool things.\n"
                ""
            };
    }

    rpc post_account(AccountRequest) returns (AccountResponse) {
        option (google.api.http) = { post: "/account" };
    }
}
```

will generate

```elixir
defmodule API.Presidio.AccountService do
  use Protobuf.Service

  @doc """
  Get user account information

  This adds cool things.
  """
  rpc :account, API.Presidio.AccountRequest, API.Presidio.AccountResponse, get: "/account"
  rpc :post_account, API.Presidio.AccountRequest, API.Presidio.AccountResponse, post: "/account"
end
```

which can be read in an app as:

```elixir
Code.fetch_docs(API.Presidio.AccountService)
{:docs_v1, 94, :elixir, "text/markdown", :none, %{},
 [
   {{:function, :rpcs, 0}, 97, ["rpcs()"],
    %{"en" => "Get user account information\n\nThis adds cool things.\n"}, %{}}
 ]}
```